### PR TITLE
Fix Verifier Key deserialization.

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -103,9 +103,21 @@ where
         format: SerdeFormat,
         #[cfg(feature = "circuit-params")] params: ConcreteCircuit::Params,
     ) -> io::Result<Self> {
+        // Maximum allowed value for parameter `k`, the log-size of the circuit.
+        const MAX_CIRCUIT_SIZE: u32 = 32;
         let mut k = [0u8; 4];
         reader.read_exact(&mut k)?;
         let k = u32::from_be_bytes(k);
+        if k > MAX_CIRCUIT_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "circuit size value (k): {} exceeds maxium: {}",
+                    k, MAX_CIRCUIT_SIZE
+                ),
+            ));
+        }
+
         let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(
             k,
             #[cfg(feature = "circuit-params")]


### PR DESCRIPTION
# Description

The desiarlization of a VK involves recovering the circuit log size parameter `k`. This value is read directly as a `u32` without any checks. Its maximum allowed value is then `~2^( 2^32)`, which can become an issue since it is used later in the desiarliazation  to process the selector by initializing vectors of size `2^k`:
https://github.com/input-output-hk/halo2/blob/b61d14bc15fd8692415f3dbbaa737a088ea57400/halo2_proofs/src/plonk.rs#L125C36-L125C36


There is a theoretic limitation of this value by the 2-adicity of the scalar field of the curves we use. All of the curves have a 2-adicity `<=32`.

# Changes
Add a check that ensures `k <=32`.