### PR TITLE
Reduce KZG parameters for proof verifier.

### DIFF
--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -179,7 +179,7 @@ fn main() {
     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
     assert!(verify_proof::<
         KZGCommitmentScheme<Bn256>,
-        VerifierGWC<'_, Bn256>,
+        VerifierGWC<Bn256>,
         Challenge255<G1Affine>,
         Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
         SingleStrategy<'_, Bn256>,

--- a/halo2_proofs/examples/serialization.rs
+++ b/halo2_proofs/examples/serialization.rs
@@ -11,6 +11,7 @@ use halo2_proofs::{
         ConstraintSystem, Error, Fixed, Instance, ProvingKey,
     },
     poly::{
+        commitment::ParamsProver,
         kzg::{
             commitment::{KZGCommitmentScheme, ParamsKZG},
             multiopen::{ProverGWC, VerifierGWC},
@@ -173,7 +174,8 @@ fn main() {
     .expect("prover should not fail");
     let proof = transcript.finalize();
 
-    let strategy = SingleStrategy::new(&params);
+    let verifier_params = params.into_verifier_params();
+    let strategy = SingleStrategy::new(&verifier_params);
     let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
     assert!(verify_proof::<
         KZGCommitmentScheme<Bn256>,
@@ -182,7 +184,7 @@ fn main() {
         Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
         SingleStrategy<'_, Bn256>,
     >(
-        &params,
+        &verifier_params,
         pk.get_vk(),
         strategy,
         &[instances],

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -7,7 +7,7 @@ use super::{
     VerifyingKey,
 };
 use crate::arithmetic::compute_inner_product;
-use crate::poly::commitment::{CommitmentScheme, Verifier};
+use crate::poly::commitment::{CommitmentScheme, ParamsVerifier, Verifier};
 use crate::poly::VerificationStrategy;
 use crate::poly::{
     commitment::{Blind, Params},
@@ -52,7 +52,9 @@ where
                 instance
                     .iter()
                     .map(|instance| {
-                        if instance.len() > params.n() as usize - (vk.cs.blinding_factors() + 1) {
+                        if instance.len()
+                            > params.trimed_size() as usize - (vk.cs.blinding_factors() + 1)
+                        {
                             return Err(Error::InstanceTooLarge);
                         }
                         let mut poly = instance.to_vec();

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -87,9 +87,6 @@ pub trait ParamsProver<'params, C: CurveAffine>: Params<'params, C> {
     fn commit(&self, poly: &Polynomial<C::ScalarExt, Coeff>, r: Blind<C::ScalarExt>)
         -> C::CurveExt;
 
-    /// Getter for g generators
-    fn get_g(&self) -> &[C];
-
     /// Returns verification parameters.
     fn into_verifier_params(self) -> Self::ParamsVerifier;
 }

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -91,11 +91,15 @@ pub trait ParamsProver<'params, C: CurveAffine>: Params<'params, C> {
     fn get_g(&self) -> &[C];
 
     /// Returns verification parameters.
-    fn verifier_params(&'params self) -> &'params Self::ParamsVerifier;
+    fn into_verifier_params(self) -> Self::ParamsVerifier;
 }
 
 /// Verifier specific functionality with circuit constraints
-pub trait ParamsVerifier<'params, C: CurveAffine>: Params<'params, C> {}
+pub trait ParamsVerifier<'params, C: CurveAffine>: Params<'params, C> {
+    /// Returns the size of the trimed parameters.
+    /// This is the maximum size of the PI that these params can be used to commit to.
+    fn trimed_size(&self) -> u64;
+}
 
 /// Multi scalar multiplication engine
 pub trait MSM<C: CurveAffine>: Clone + Debug + Send + Sync {

--- a/halo2_proofs/src/poly/ipa/commitment.rs
+++ b/halo2_proofs/src/poly/ipa/commitment.rs
@@ -226,10 +226,6 @@ impl<'params, C: CurveAffine> ParamsProver<'params, C> for ParamsIPA<C> {
 
         best_multiexp::<C>(&tmp_scalars, &tmp_bases)
     }
-
-    fn get_g(&self) -> &[C] {
-        &self.g
-    }
 }
 
 #[cfg(test)]

--- a/halo2_proofs/src/poly/ipa/commitment.rs
+++ b/halo2_proofs/src/poly/ipa/commitment.rs
@@ -56,7 +56,12 @@ impl<C: CurveAffine> CommitmentScheme for IPACommitmentScheme<C> {
 /// Verifier parameters
 pub type ParamsVerifierIPA<C> = ParamsIPA<C>;
 
-impl<'params, C: CurveAffine> ParamsVerifier<'params, C> for ParamsIPA<C> {}
+impl<'params, C: CurveAffine> ParamsVerifier<'params, C> for ParamsIPA<C> {
+    fn trimed_size(&self) -> u64 {
+        // IPA parameters are never trimed so their sized is always the full size of the domain.
+        self.n
+    }
+}
 
 impl<'params, C: CurveAffine> Params<'params, C> for ParamsIPA<C> {
     type MSM = MSMIPA<'params, C>;
@@ -145,7 +150,7 @@ impl<'params, C: CurveAffine> Params<'params, C> for ParamsIPA<C> {
 impl<'params, C: CurveAffine> ParamsProver<'params, C> for ParamsIPA<C> {
     type ParamsVerifier = ParamsVerifierIPA<C>;
 
-    fn verifier_params(&'params self) -> &'params Self::ParamsVerifier {
+    fn into_verifier_params(self) -> Self::ParamsVerifier {
         self
     }
 

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -478,7 +478,7 @@ where
 
     fn downsize(&mut self, _k: u32) {
         // Verifier parameters cannot be downsized since they do not contain the original powers of g.
-        unimplemented!()
+        panic!("Verifier parameters cannot be downsized. You may want to use `trim` instead.")
     }
 
     fn empty_msm(&'params self) -> MSMKZG<E> {

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -26,6 +26,24 @@ pub struct ParamsKZG<E: Engine> {
     pub(crate) s_g2: E::G2Affine,
 }
 
+/// KZG multi-open verification parameters.
+/// These parameters need to support the veification of a KZG PLONK proof.
+/// As a consequence, they need to support the computation of the PI commitment.
+#[derive(Debug, Clone)]
+pub struct ParamsVerifierKZG<E: Engine> {
+    // Log-size of the domain.
+    pub(crate) k: u32,
+    // Domain size.
+    pub(crate) n: u64,
+    // This is the maximum size of PI supported.
+    pub(crate) trimed_size: u32,
+
+    pub(crate) g_lagrange: Vec<E::G1Affine>,
+    pub(crate) g: E::G1Affine,
+    pub(crate) g2: E::G2Affine,
+    pub(crate) s_g2: E::G2Affine,
+}
+
 /// Umbrella commitment scheme construction for all KZG variants
 #[derive(Debug)]
 pub struct KZGCommitmentScheme<E: Engine> {
@@ -267,10 +285,138 @@ where
     }
 }
 
-// TODO: see the issue at https://github.com/appliedzkp/halo2/issues/45
-// So we probably need much smaller verifier key. However for new bases in g1 should be in verifier keys.
-/// KZG multi-open verification parameters
-pub type ParamsVerifierKZG<C> = ParamsKZG<C>;
+impl<E: Engine + Debug> ParamsVerifierKZG<E>
+where
+    E::Scalar: PrimeField,
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
+{
+    /// Reduce the size of the verifier parameters by eliminating elements of `g_lagrange`.
+    /// The resulting parameters are only able to compute commitments up to the inputed `size`.
+    /// As a result, this will be the maximum size of PI supported.
+    pub fn trim(mut self, size: usize) -> Self {
+        assert!(size as u64 <= self.n);
+        self.trimed_size = size as u32;
+        self.g_lagrange.truncate(size);
+        self
+    }
+
+    /// Writes verifier parameters to buffer.
+    pub fn write_custom<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()>
+    where
+        E::G2Affine: SerdeCurveAffine,
+    {
+        writer.write_all(&self.k.to_le_bytes())?;
+        writer.write_all(&self.trimed_size.to_le_bytes())?;
+        for el in self.g_lagrange.iter() {
+            el.write(writer, format)?;
+        }
+        self.g.write(writer, format)?;
+        self.g2.write(writer, format)?;
+        self.s_g2.write(writer, format)?;
+        Ok(())
+    }
+
+    /// Reads verifier parameters from a buffer.
+    pub fn read_custom<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self>
+    where
+        E::G2Affine: SerdeCurveAffine,
+    {
+        let mut k = [0u8; 4];
+        reader.read_exact(&mut k[..])?;
+        let k = u32::from_le_bytes(k);
+        let n = 1 << k;
+        // This is a generous bound on the size of the domain.
+        debug_assert!(k < 32);
+
+        let mut trimed_size = [0u8; 4];
+        reader.read_exact(&mut trimed_size[..])?;
+        let trimed_size = u32::from_le_bytes(trimed_size);
+
+        let g_lagrange = match format {
+            SerdeFormat::Processed => {
+                use group::GroupEncoding;
+                let load_points_from_file_parallelly =
+                    |reader: &mut R| -> io::Result<Vec<Option<E::G1Affine>>> {
+                        let mut points_compressed = vec![
+                                <<E as Engine>::G1Affine as GroupEncoding>::Repr::default();
+                                trimed_size as usize
+                            ];
+                        for points_compressed in points_compressed.iter_mut() {
+                            reader.read_exact((*points_compressed).as_mut())?;
+                        }
+
+                        let mut points = vec![Option::<E::G1Affine>::None; trimed_size as usize];
+                        parallelize(&mut points, |points, chunks| {
+                            for (i, point) in points.iter_mut().enumerate() {
+                                *point = Option::from(E::G1Affine::from_bytes(
+                                    &points_compressed[chunks + i],
+                                ));
+                            }
+                        });
+                        Ok(points)
+                    };
+
+                let g_lagrange = load_points_from_file_parallelly(reader)?;
+                g_lagrange
+                    .iter()
+                    .map(|point| {
+                        point.ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::Other, "invalid point encoding")
+                        })
+                    })
+                    .collect::<Result<_, _>>()?
+            }
+            SerdeFormat::RawBytes => (0..trimed_size)
+                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format))
+                .collect::<Result<Vec<_>, _>>()?,
+            SerdeFormat::RawBytesUnchecked => (0..trimed_size)
+                .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format).unwrap())
+                .collect::<Vec<_>>(),
+        };
+        let g = <E::G1Affine as SerdeCurveAffine>::read(reader, format)?;
+        let g2 = E::G2Affine::read(reader, format)?;
+        let s_g2 = E::G2Affine::read(reader, format)?;
+
+        Ok(Self {
+            k,
+            n,
+            trimed_size,
+            g_lagrange,
+            g,
+            g2,
+            s_g2,
+        })
+    }
+}
+
+impl<E: Engine + Debug> From<ParamsKZG<E>> for ParamsVerifierKZG<E> {
+    fn from(value: ParamsKZG<E>) -> Self {
+        Self {
+            k: value.k,
+            n: value.n,
+            trimed_size: value.n as u32,
+            g_lagrange: value.g_lagrange.clone(),
+            g: value.g[0],
+            g2: value.g2,
+            s_g2: value.s_g2,
+        }
+    }
+}
+
+impl<E: Engine + Debug> From<&ParamsKZG<E>> for ParamsVerifierKZG<E> {
+    fn from(value: &ParamsKZG<E>) -> Self {
+        Self {
+            k: value.k,
+            n: value.n,
+            trimed_size: value.n as u32,
+            g_lagrange: value.g_lagrange.clone(),
+            g: value.g[0],
+            g2: value.g2,
+            s_g2: value.s_g2,
+        }
+    }
+}
 
 impl<'params, E: Engine + Debug> Params<'params, E::G1Affine> for ParamsKZG<E>
 where
@@ -326,12 +472,64 @@ where
     }
 }
 
-impl<'params, E: Engine + Debug> ParamsVerifier<'params, E::G1Affine> for ParamsKZG<E>
+impl<'params, E: Engine + Debug> Params<'params, E::G1Affine> for ParamsVerifierKZG<E>
 where
     E::Scalar: PrimeField,
     E::G1Affine: SerdeCurveAffine,
     E::G2Affine: SerdeCurveAffine,
 {
+    type MSM = MSMKZG<E>;
+
+    fn k(&self) -> u32 {
+        self.k
+    }
+
+    fn n(&self) -> u64 {
+        self.n
+    }
+
+    fn downsize(&mut self, _k: u32) {
+        // Verifier parameters cannot be downsized since they do not contain the original powers of g.
+        unimplemented!()
+    }
+
+    fn empty_msm(&'params self) -> MSMKZG<E> {
+        MSMKZG::new()
+    }
+
+    fn commit_lagrange(
+        &self,
+        poly: &Polynomial<E::Scalar, LagrangeCoeff>,
+        _: Blind<E::Scalar>,
+    ) -> E::G1 {
+        let mut scalars = Vec::with_capacity(poly.len());
+        scalars.extend(poly.iter());
+        let bases = &self.g_lagrange;
+        let size = scalars.len();
+        assert!(bases.len() >= size);
+        best_multiexp(&scalars, &bases[0..size])
+    }
+
+    /// Writes params to a buffer.
+    fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        self.write_custom(writer, SerdeFormat::RawBytes)
+    }
+
+    /// Reads params from a buffer.
+    fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        Self::read_custom(reader, SerdeFormat::RawBytes)
+    }
+}
+
+impl<'params, E: Engine + Debug> ParamsVerifier<'params, E::G1Affine> for ParamsVerifierKZG<E>
+where
+    E::Scalar: PrimeField,
+    E::G1Affine: SerdeCurveAffine,
+    E::G2Affine: SerdeCurveAffine,
+{
+    fn trimed_size(&self) -> u64 {
+        self.trimed_size as u64
+    }
 }
 
 impl<'params, E: Engine + Debug> ParamsProver<'params, E::G1Affine> for ParamsKZG<E>
@@ -342,8 +540,8 @@ where
 {
     type ParamsVerifier = ParamsVerifierKZG<E>;
 
-    fn verifier_params(&'params self) -> &'params Self::ParamsVerifier {
-        self
+    fn into_verifier_params(self) -> Self::ParamsVerifier {
+        self.into()
     }
 
     fn new(k: u32) -> Self {

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -39,8 +39,6 @@ pub struct ParamsVerifierKZG<E: Engine> {
     pub(crate) trimed_size: u32,
 
     pub(crate) g_lagrange: Vec<E::G1Affine>,
-    pub(crate) g: E::G1Affine,
-    pub(crate) g2: E::G2Affine,
     pub(crate) s_g2: E::G2Affine,
 }
 
@@ -311,8 +309,6 @@ where
         for el in self.g_lagrange.iter() {
             el.write(writer, format)?;
         }
-        self.g.write(writer, format)?;
-        self.g2.write(writer, format)?;
         self.s_g2.write(writer, format)?;
         Ok(())
     }
@@ -374,8 +370,6 @@ where
                 .map(|_| <E::G1Affine as SerdeCurveAffine>::read(reader, format).unwrap())
                 .collect::<Vec<_>>(),
         };
-        let g = <E::G1Affine as SerdeCurveAffine>::read(reader, format)?;
-        let g2 = E::G2Affine::read(reader, format)?;
         let s_g2 = E::G2Affine::read(reader, format)?;
 
         Ok(Self {
@@ -383,8 +377,6 @@ where
             n,
             trimed_size,
             g_lagrange,
-            g,
-            g2,
             s_g2,
         })
     }
@@ -397,8 +389,6 @@ impl<E: Engine + Debug> From<ParamsKZG<E>> for ParamsVerifierKZG<E> {
             n: value.n,
             trimed_size: value.n as u32,
             g_lagrange: value.g_lagrange.clone(),
-            g: value.g[0],
-            g2: value.g2,
             s_g2: value.s_g2,
         }
     }
@@ -411,8 +401,6 @@ impl<E: Engine + Debug> From<&ParamsKZG<E>> for ParamsVerifierKZG<E> {
             n: value.n,
             trimed_size: value.n as u32,
             g_lagrange: value.g_lagrange.clone(),
-            g: value.g[0],
-            g2: value.g2,
             s_g2: value.s_g2,
         }
     }
@@ -555,10 +543,6 @@ where
         let size = scalars.len();
         assert!(bases.len() >= size);
         best_multiexp(&scalars, &bases[0..size])
-    }
-
-    fn get_g(&self) -> &[E::G1Affine] {
-        &self.g
     }
 }
 

--- a/halo2_proofs/src/poly/kzg/msm.rs
+++ b/halo2_proofs/src/poly/kzg/msm.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use super::commitment::ParamsKZG;
+use super::commitment::ParamsVerifierKZG;
 use crate::{
     arithmetic::{best_multiexp, parallelize},
     poly::commitment::MSM,
@@ -109,8 +109,10 @@ impl<E: Engine + Debug> PreMSM<E> {
     }
 }
 
-impl<'params, E: MultiMillerLoop + Debug> From<&'params ParamsKZG<E>> for DualMSM<'params, E> {
-    fn from(params: &'params ParamsKZG<E>) -> Self {
+impl<'params, E: MultiMillerLoop + Debug> From<&'params ParamsVerifierKZG<E>>
+    for DualMSM<'params, E>
+{
+    fn from(params: &'params ParamsVerifierKZG<E>) -> Self {
         DualMSM::new(params)
     }
 }
@@ -118,14 +120,14 @@ impl<'params, E: MultiMillerLoop + Debug> From<&'params ParamsKZG<E>> for DualMS
 /// Two channel MSM accumulator
 #[derive(Debug, Clone)]
 pub struct DualMSM<'a, E: Engine> {
-    pub(crate) params: &'a ParamsKZG<E>,
+    pub(crate) params: &'a ParamsVerifierKZG<E>,
     pub(crate) left: MSMKZG<E>,
     pub(crate) right: MSMKZG<E>,
 }
 
 impl<'a, E: MultiMillerLoop + Debug> DualMSM<'a, E> {
     /// Create a new two channel MSM accumulator instance
-    pub fn new(params: &'a ParamsKZG<E>) -> Self {
+    pub fn new(params: &'a ParamsVerifierKZG<E>) -> Self {
         Self {
             params,
             left: MSMKZG::new(),

--- a/halo2_proofs/src/poly/kzg/msm.rs
+++ b/halo2_proofs/src/poly/kzg/msm.rs
@@ -5,6 +5,7 @@ use crate::{
     arithmetic::{best_multiexp, parallelize},
     poly::commitment::MSM,
 };
+use group::prime::PrimeCurveAffine;
 use group::{Curve, Group};
 use halo2curves::pairing::{Engine, MillerLoopResult, MultiMillerLoop};
 
@@ -63,7 +64,6 @@ impl<E: Engine + Debug> MSM<E::G1Affine> for MSMKZG<E> {
     }
 
     fn eval(&self) -> E::G1 {
-        use group::prime::PrimeCurveAffine;
         let mut bases = vec![E::G1Affine::identity(); self.scalars.len()];
         E::G1::batch_normalize(&self.bases, &mut bases);
         best_multiexp(&self.scalars, &bases)
@@ -150,7 +150,7 @@ impl<'a, E: MultiMillerLoop + Debug> DualMSM<'a, E> {
     /// Performs final pairing check with given verifier params and two channel linear combination
     pub fn check(self) -> bool {
         let s_g2_prepared = E::G2Prepared::from(self.params.s_g2);
-        let n_g2_prepared = E::G2Prepared::from(-self.params.g2);
+        let n_g2_prepared = E::G2Prepared::from(-E::G2Affine::generator());
 
         let left = self.left.eval();
         let right = self.right.eval();

--- a/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/gwc/verifier.rs
@@ -5,7 +5,7 @@ use crate::arithmetic::powers;
 use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::Verifier;
 use crate::poly::commitment::MSM;
-use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
+use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsVerifierKZG};
 use crate::poly::kzg::msm::{DualMSM, MSMKZG};
 use crate::poly::kzg::strategy::GuardKZG;
 use crate::poly::query::Query;
@@ -19,7 +19,7 @@ use halo2curves::pairing::{Engine, MultiMillerLoop};
 #[derive(Debug)]
 /// Concrete KZG verifier with GWC variant
 pub struct VerifierGWC<'params, E: Engine> {
-    params: &'params ParamsKZG<E>,
+    params: &'params ParamsVerifierKZG<E>,
 }
 
 impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierGWC<'params, E>
@@ -34,7 +34,7 @@ where
 
     const QUERY_INSTANCE: bool = false;
 
-    fn new(params: &'params ParamsKZG<E>) -> Self {
+    fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         Self { params }
     }
 
@@ -115,7 +115,7 @@ where
 
         msm_accumulator.right.add_msm(&witness_with_aux);
         msm_accumulator.right.add_msm(&commitment_multi);
-        let g0: E::G1 = self.params.g[0].into();
+        let g0: E::G1 = self.params.g.into();
         msm_accumulator.right.append_term(eval_multi, -g0);
 
         Ok(Self::Guard::new(msm_accumulator))

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
@@ -8,7 +8,7 @@ use crate::arithmetic::{
 use crate::helpers::SerdeCurveAffine;
 use crate::poly::commitment::Verifier;
 use crate::poly::commitment::MSM;
-use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsKZG};
+use crate::poly::kzg::commitment::{KZGCommitmentScheme, ParamsVerifierKZG};
 use crate::poly::kzg::msm::DualMSM;
 use crate::poly::kzg::msm::{PreMSM, MSMKZG};
 use crate::poly::kzg::strategy::GuardKZG;
@@ -22,7 +22,7 @@ use std::ops::MulAssign;
 /// Concrete KZG multiopen verifier with SHPLONK variant
 #[derive(Debug)]
 pub struct VerifierSHPLONK<'params, E: Engine> {
-    params: &'params ParamsKZG<E>,
+    params: &'params ParamsVerifierKZG<E>,
 }
 
 impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierSHPLONK<'params, E>
@@ -37,7 +37,7 @@ where
 
     const QUERY_INSTANCE: bool = false;
 
-    fn new(params: &'params ParamsKZG<E>) -> Self {
+    fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         Self { params }
     }
 
@@ -124,7 +124,7 @@ where
             r_outer_acc += power_of_v * r_inner_acc * z_diff_i;
         }
         let mut outer_msm = outer_msm.normalize();
-        let g1: E::G1 = self.params.g[0].into();
+        let g1: E::G1 = self.params.g.into();
         outer_msm.append_term(-r_outer_acc, g1);
         outer_msm.append_term(-z_0, h1.into());
         outer_msm.append_term(*u, h2.into());

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/verifier.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use super::ChallengeY;
 use super::{construct_intermediate_sets, ChallengeU, ChallengeV};
@@ -16,16 +17,18 @@ use crate::poly::query::{CommitmentReference, VerifierQuery};
 use crate::poly::Error;
 use crate::transcript::{EncodedChallenge, TranscriptRead};
 use ff::{Field, PrimeField};
+use group::prime::PrimeCurveAffine;
 use halo2curves::pairing::{Engine, MultiMillerLoop};
 use std::ops::MulAssign;
 
 /// Concrete KZG multiopen verifier with SHPLONK variant
 #[derive(Debug)]
-pub struct VerifierSHPLONK<'params, E: Engine> {
-    params: &'params ParamsVerifierKZG<E>,
+pub struct VerifierSHPLONK<E: Engine> {
+    // params: &'params ParamsVerifierKZG<E>,
+    _p0: PhantomData<E>,
 }
 
-impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierSHPLONK<'params, E>
+impl<'params, E> Verifier<'params, KZGCommitmentScheme<E>> for VerifierSHPLONK<E>
 where
     E: MultiMillerLoop + Debug,
     E::Scalar: PrimeField + Ord,
@@ -37,8 +40,10 @@ where
 
     const QUERY_INSTANCE: bool = false;
 
-    fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
-        Self { params }
+    fn new(_params: &'params ParamsVerifierKZG<E>) -> Self {
+        Self {
+            _p0: PhantomData::default(),
+        }
     }
 
     /// Verify a multi-opening proof
@@ -124,7 +129,7 @@ where
             r_outer_acc += power_of_v * r_inner_acc * z_diff_i;
         }
         let mut outer_msm = outer_msm.normalize();
-        let g1: E::G1 = self.params.g.into();
+        let g1: E::G1 = E::G1Affine::generator().into();
         outer_msm.append_term(-r_outer_acc, g1);
         outer_msm.append_term(-z_0, h1.into());
         outer_msm.append_term(*u, h2.into());

--- a/halo2_proofs/src/poly/kzg/strategy.rs
+++ b/halo2_proofs/src/poly/kzg/strategy.rs
@@ -1,5 +1,5 @@
 use super::{
-    commitment::{KZGCommitmentScheme, ParamsKZG},
+    commitment::{KZGCommitmentScheme, ParamsVerifierKZG},
     msm::DualMSM,
 };
 use crate::{
@@ -47,7 +47,7 @@ pub struct AccumulatorStrategy<'params, E: Engine> {
 
 impl<'params, E: MultiMillerLoop + Debug> AccumulatorStrategy<'params, E> {
     /// Constructs an empty batch verifier
-    pub fn new(params: &'params ParamsKZG<E>) -> Self {
+    pub fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         AccumulatorStrategy {
             msm_accumulator: DualMSM::new(params),
         }
@@ -67,7 +67,7 @@ pub struct SingleStrategy<'params, E: Engine> {
 
 impl<'params, E: MultiMillerLoop + Debug> SingleStrategy<'params, E> {
     /// Constructs an empty batch verifier
-    pub fn new(params: &'params ParamsKZG<E>) -> Self {
+    pub fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         SingleStrategy {
             msm: DualMSM::new(params),
         }
@@ -91,7 +91,7 @@ where
 {
     type Output = Self;
 
-    fn new(params: &'params ParamsKZG<E>) -> Self {
+    fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         AccumulatorStrategy::new(params)
     }
 
@@ -130,7 +130,7 @@ where
 {
     type Output = ();
 
-    fn new(params: &'params ParamsKZG<E>) -> Self {
+    fn new(params: &'params ParamsVerifierKZG<E>) -> Self {
         Self::new(params)
     }
 

--- a/halo2_proofs/src/poly/multiopen_test.rs
+++ b/halo2_proofs/src/poly/multiopen_test.rs
@@ -36,7 +36,7 @@ mod test {
             Blake2bWrite<_, _, Challenge255<_>>,
         >(&params);
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify::<
             IPACommitmentScheme<EqAffine>,
@@ -44,7 +44,7 @@ mod test {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], false);
+        >(&verifier_params, &proof[..], false);
 
         verify::<
             IPACommitmentScheme<EqAffine>,
@@ -52,7 +52,7 @@ mod test {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], true);
+        >(&verifier_params, &proof[..], true);
     }
 
     #[test]
@@ -73,7 +73,7 @@ mod test {
             Keccak256Write<_, _, Challenge255<_>>,
         >(&params);
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify::<
             IPACommitmentScheme<EqAffine>,
@@ -81,7 +81,7 @@ mod test {
             _,
             Keccak256Read<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], false);
+        >(&verifier_params, &proof[..], false);
 
         verify::<
             IPACommitmentScheme<EqAffine>,
@@ -89,7 +89,7 @@ mod test {
             _,
             Keccak256Read<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], true);
+        >(&verifier_params, &proof[..], true);
     }
 
     #[test]
@@ -106,10 +106,10 @@ mod test {
         let proof =
             create_proof::<_, ProverGWC<_>, _, Blake2bWrite<_, _, Challenge255<_>>>(&params);
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify::<_, VerifierGWC<_>, _, Blake2bRead<_, _, Challenge255<_>>, AccumulatorStrategy<_>>(
-            verifier_params,
+            &verifier_params,
             &proof[..],
             false,
         );
@@ -120,7 +120,7 @@ mod test {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], true);
+        >(&verifier_params, &proof[..], true);
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod test {
             Blake2bWrite<_, _, Challenge255<_>>,
         >(&params);
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify::<
             KZGCommitmentScheme<Bn256>,
@@ -149,7 +149,7 @@ mod test {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], false);
+        >(&verifier_params, &proof[..], false);
 
         verify::<
             KZGCommitmentScheme<Bn256>,
@@ -157,7 +157,7 @@ mod test {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, &proof[..], true);
+        >(&verifier_params, &proof[..], true);
     }
 
     fn verify<

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -549,7 +549,7 @@ fn plonk_api() {
             rng, &params, &pk,
         );
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify_proof::<
             _,
@@ -557,7 +557,7 @@ fn plonk_api() {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, pk.get_vk(), &proof[..]);
+        >(&verifier_params, pk.get_vk(), &proof[..]);
     }
 
     fn test_plonk_api_shplonk() {
@@ -578,7 +578,7 @@ fn plonk_api() {
             rng, &params, &pk,
         );
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify_proof::<
             _,
@@ -586,7 +586,7 @@ fn plonk_api() {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, pk.get_vk(), &proof[..]);
+        >(&verifier_params, pk.get_vk(), &proof[..]);
     }
 
     fn test_plonk_api_ipa() {
@@ -607,7 +607,7 @@ fn plonk_api() {
             rng, &params, &pk,
         );
 
-        let verifier_params = params.verifier_params();
+        let verifier_params = params.into_verifier_params();
 
         verify_proof::<
             _,
@@ -615,7 +615,7 @@ fn plonk_api() {
             _,
             Blake2bRead<_, _, Challenge255<_>>,
             AccumulatorStrategy<_>,
-        >(verifier_params, pk.get_vk(), &proof[..]);
+        >(&verifier_params, pk.get_vk(), &proof[..]);
 
         // Check that the verification key has not changed unexpectedly
         {


### PR DESCRIPTION
# Description

In order to verify a KZG proof, it is necessary to provide the commitment scheme parameters `ParamsVerifier`. Currently, these parameters for KZG are the same struct as the parameters for the prover. For IPA, this is not a big issue, but it is for KZG, where the prover parameters are linear in size with number of constraints of the circuit, while the verifier is just a single G2 point.

# Changes

 - Add a new struct `ParamsVerifierZKG` with only the necessary elements for a KZG based proof verification.
**Note:** This proof verification not only involves a KZG verification, but also a commitment to the PI values of the circuit. As a result, these parameters contain a vector of commitments to the Lagrange polynomials of the corresponding domain. The size of this vector doesn't have to be the full `n` (size of the domain), it can be adjusted to the number of expected PI.

 - Remove `get_g` from Params.
 - Change `verifier_params(...)` -> `into_verifier_params(...)`
   Since the Verifier params are now a different struct, this function now consumes the parameters and creates a new instance of the verifier parameters, instead of dealing with references.
   
 --- 
 This PR solves the bulky parameters issue but the result is not 100% satisfactory. I think a refactor around the commitment scheme parameters traits and structs is needed. Here are some of the reasons:
  - We could have a better separation or organization around what the commitment scheme verifier and proof verifier.
  Ideally the KZG verifier parameters should only contain the `s_g2` point, not the commitments to Lagrange polynomials.
  - The interfaces defined by the traits `Params`, `ProverParams` and `VerifierParams` have some problems:
     + `trimed_size` does not make a lot of sense for IPA parametes, it should be something specific to KZG.
     + `downsize` may not be suitable for `Params` since KZG verifier params cannot be downsized.
     + `commit_lagrange` may not be suitable for `Params` either. The verifier parameters should not need to support this capability.
  
  After removing the G1 and G2  generators from the parameters ( credit to Miguel for noticing this! ) another design issue was revealed: The verifier (Shplonk and Gwc)  are not using the parameters at all!  The reason is quite simple, the output of `verify_proof` is a `Guard`, an object that accumulates partially verified proofs and that can be finalized to complete the verification of a batch of proof. The pairing is only used in the last step, so the KZG parameters are not needed until then. 
     