### PR TITLE
Reduce size of proving keys and verifying keys

### DIFF
--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -206,7 +206,16 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
     C::Scalar: FromUniformBytes<64>,
 {
-    keygen_vk_custom(params, circuit, true)
+    // We disable "complex selectors" for now, because they are not properly
+    // serialized. At the moment, they are stored as boolean vectors containing
+    // their value on every single row. This makes the verification key size
+    // linear when they are enabled.
+    // Furthermore, having complex selectors makes the cs structure variable
+    // depending on the selector instantiation. This is undesirable.
+    // In the future, if we want to enjoy the benefits of complex selectors
+    // (about a 10-20% improvement in proof size and verifying key payload size)
+    // we need to improve their serialization.
+    keygen_vk_custom(params, circuit, false)
 }
 
 /// Generate a `VerifyingKey` from an instance of `Circuit`.

--- a/halo2_proofs/src/plonk/permutation.rs
+++ b/halo2_proofs/src/plonk/permutation.rs
@@ -1,5 +1,7 @@
 //! Implementation of permutation argument.
 
+use self::keygen::compute_polys_and_cosets;
+
 use super::circuit::{Any, Column};
 use crate::{
     arithmetic::CurveAffine,
@@ -7,7 +9,7 @@ use crate::{
         polynomial_slice_byte_length, read_polynomial_vec, write_polynomial_slice,
         SerdeCurveAffine, SerdePrimeField,
     },
-    poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial},
+    poly::{Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial},
     SerdeFormat,
 };
 
@@ -138,10 +140,14 @@ where
     C::Scalar: SerdePrimeField,
 {
     /// Reads proving key for a single permutation argument from buffer using `Polynomial::read`.  
-    pub(super) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
+    pub(super) fn read<R: io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+        domain: &EvaluationDomain<C::Scalar>,
+        p: &Argument,
+    ) -> io::Result<Self> {
         let permutations = read_polynomial_vec(reader, format)?;
-        let polys = read_polynomial_vec(reader, format)?;
-        let cosets = read_polynomial_vec(reader, format)?;
+        let (polys, cosets) = compute_polys_and_cosets::<C>(domain, p, &permutations);
         Ok(ProvingKey {
             permutations,
             polys,
@@ -156,8 +162,6 @@ where
         format: SerdeFormat,
     ) -> io::Result<()> {
         write_polynomial_slice(&self.permutations, writer, format)?;
-        write_polynomial_slice(&self.polys, writer, format)?;
-        write_polynomial_slice(&self.cosets, writer, format)?;
         Ok(())
     }
 }
@@ -166,7 +170,5 @@ impl<C: CurveAffine> ProvingKey<C> {
     /// Gets the total number of bytes in the serialization of `self`
     pub(super) fn bytes_length(&self) -> usize {
         polynomial_slice_byte_length(&self.permutations)
-            + polynomial_slice_byte_length(&self.polys)
-            + polynomial_slice_byte_length(&self.cosets)
     }
 }


### PR DESCRIPTION
For proving keys, on "write" we skip some information which we can easily recompute on "read".

For verifying keys, we disable the complex selector flag globally.