### PR TITLE
Allow `downsize` on verifier params

### DIFF
--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -474,9 +474,10 @@ where
         self.n
     }
 
-    fn downsize(&mut self, _k: u32) {
-        // Verifier parameters cannot be downsized since they do not contain the original powers of g.
-        panic!("Verifier parameters cannot be downsized. You may want to use `trim` instead.")
+    fn downsize(&mut self, k: u32) {
+        assert!(k <= self.k);
+        self.k = k;
+        self.n = 1 << k;
     }
 
     fn empty_msm(&'params self) -> MSMKZG<E> {

--- a/halo2_proofs/src/poly/kzg/commitment.rs
+++ b/halo2_proofs/src/poly/kzg/commitment.rs
@@ -476,8 +476,12 @@ where
 
     fn downsize(&mut self, k: u32) {
         assert!(k <= self.k);
+        let n = 1 << k;
+        if n < self.trimed_size {
+            *self = self.clone().trim(n as usize);
+        }
         self.k = k;
-        self.n = 1 << k;
+        self.n = n as u64;
     }
 
     fn empty_msm(&'params self) -> MSMKZG<E> {


### PR DESCRIPTION
This is currently _required_, as verification checks `n` and/or `k` against the proof / verifier key, and fails if these do not match. As a result, I need to be able to interpret the params as ones with a lower `k`, even if this is a noop.