### PR TITLE
read_vk does not need to receive the compiled circuit as input

### DIFF
--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -55,6 +55,10 @@ where
     #[cfg(not(feature = "circuit-params"))]
     ConcreteCircuit::configure(&mut cs);
 
+    // we still need to replace selectors with fixed Expressions in `cs`
+    let fake_selectors = vec![vec![]; cs.num_selectors()];
+    let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors);
+
     let cs_mid: ConstraintSystemMid<_> = cs.into();
     VerifyingKey::read(reader, format, cs_mid.into())
 }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -31,7 +31,7 @@ use group::ff::FromUniformBytes;
 use halo2_backend::helpers::{SerdeCurveAffine, SerdeFormat, SerdePrimeField};
 use std::io;
 
-/// Reads a verification key from a buffer.
+/// Reads a verification key from a buffer without compressed selectors.
 ///
 /// Reads a curve element from the buffer and parses it according to the `format`:
 /// - `Processed`: Reads a compressed curve element and decompresses it.
@@ -58,6 +58,32 @@ where
     // we still need to replace selectors with fixed Expressions in `cs`
     let fake_selectors = vec![vec![]; cs.num_selectors()];
     let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors);
+
+    let cs_mid: ConstraintSystemMid<_> = cs.into();
+    VerifyingKey::read(reader, format, cs_mid.into())
+}
+
+/// Reads a verification key from a buffer with compressed selectors.
+///
+/// Reads a curve element from the buffer and parses it according to the `format`:
+/// - `Processed`: Reads a compressed curve element and decompresses it.
+///   Reads a field element in standard form, with endianness specified by the
+///   `PrimeField` implementation, and checks that the element is less than the modulus.
+/// - `RawBytes`: Reads an uncompressed curve element with coordinates in Montgomery form.
+///   Checks that field elements are less than modulus, and then checks that the point is on the curve.
+/// - `RawBytesUnchecked`: Reads an uncompressed curve element with coordinates in Montgomery form;
+///   does not perform any checks
+pub fn vk_read_compressed<C: SerdeCurveAffine, R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
+    reader: &mut R,
+    format: SerdeFormat,
+    k: u32,
+    circuit: &ConcreteCircuit,
+) -> io::Result<VerifyingKey<C>>
+where
+    C::Scalar: SerdePrimeField + FromUniformBytes<64>,
+{
+    let (_, _, cs) = compile_circuit(k, circuit, true)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
     let cs_mid: ConstraintSystemMid<_> = cs.into();
     VerifyingKey::read(reader, format, cs_mid.into())

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -24,7 +24,7 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
     C::Scalar: FromUniformBytes<64>,
 {
-    keygen_vk_custom(params, circuit, true)
+    keygen_vk_custom(params, circuit, false)
 }
 
 /// Generate a `VerifyingKey` from an instance of `Circuit`.
@@ -66,7 +66,7 @@ where
     P: Params<C>,
     ConcreteCircuit: Circuit<C::Scalar>,
 {
-    keygen_pk_custom(params, vk, circuit, true)
+    keygen_pk_custom(params, vk, circuit, false)
 }
 
 /// Generate a `ProvingKey` from an instance of `Circuit`.

--- a/halo2_proofs/tests/frontend_backend_split.rs
+++ b/halo2_proofs/tests/frontend_backend_split.rs
@@ -539,7 +539,7 @@ fn test_mycircuit_full_legacy() {
 
             proof
         },
-        "78aadfd46b5cc58b90d832ee47e4df57af3dfc28d1457c4ceeb5d0323a72f130",
+        "062603b4c2ab114921ffbfa95c3365b1d0d1037512062f96db1f1e4311dc0109",
     );
 }
 

--- a/halo2_proofs/tests/shuffle.rs
+++ b/halo2_proofs/tests/shuffle.rs
@@ -332,7 +332,7 @@ fn test_shuffle() {
 
     halo2_debug::test_result(
         || test_prover::<EqAffine, W, H>(K, circuit.clone(), true),
-        "8526b66a372eaeccb687c21daf358d4fdb1c9d2b7e81470317c472634c5c1470",
+        "f0b00695b05569895ca28526be6211f58cb5d3375b7143e905edc75397d4fa3c",
     );
 
     #[cfg(not(feature = "sanity-checks"))]


### PR DESCRIPTION
It is not necessary to compile the circuit to generate the VK. With its configuration it is enough. 

Closes #11 