### PR TITLE
Some parallel iters

### DIFF
--- a/halo2_backend/src/plonk/keygen.rs
+++ b/halo2_backend/src/plonk/keygen.rs
@@ -24,7 +24,9 @@ use crate::{
 use halo2_middleware::circuit::{
     Any, ColumnMid, CompiledCircuit, ConstraintSystemMid, ExpressionMid, VarMid,
 };
+use halo2_middleware::multicore::ParallelIterator;
 use halo2_middleware::{lookup, poly::Rotation, shuffle};
+use rayon::iter::IntoParallelRefIterator;
 use std::collections::HashMap;
 
 /// Creates a domain, constraint system, and configuration for a circuit.
@@ -107,19 +109,17 @@ where
     }
 
     // Compute fixeds
-
     let fixed_polys: Vec<_> = circuit
         .preprocessing
         .fixed
-        .iter()
+        .par_iter()
         .map(|poly| {
             vk.domain
                 .lagrange_to_coeff(Polynomial::new_lagrange_from_vec(poly.clone()))
         })
         .collect();
-
     let fixed_cosets = fixed_polys
-        .iter()
+        .par_iter()
         .map(|poly| vk.domain.coeff_to_extended(poly.clone()))
         .collect();
 

--- a/halo2_backend/src/plonk/permutation/keygen.rs
+++ b/halo2_backend/src/plonk/permutation/keygen.rs
@@ -1,6 +1,9 @@
 use group::Curve;
 use halo2_middleware::ff::{Field, PrimeField};
+use halo2_middleware::multicore::IndexedParallelIterator;
+use halo2_middleware::multicore::ParallelIterator;
 use halo2_middleware::zal::impls::H2cEngine;
+use rayon::iter::IntoParallelRefMutIterator;
 
 use super::{Argument, ProvingKey, VerifyingKey};
 use crate::{
@@ -173,35 +176,40 @@ pub(crate) fn build_pk<C: CurveAffine, P: Params<C>>(
     let mut permutations = vec![domain.empty_lagrange(); p.columns.len()];
     {
         parallelize(&mut permutations, |o, start| {
-            for (x, permutation_poly) in o.iter_mut().enumerate() {
-                let i = start + x;
-                for (j, p) in permutation_poly.iter_mut().enumerate() {
-                    let (permuted_i, permuted_j) = mapping(i, j);
-                    *p = deltaomega[permuted_i][permuted_j];
-                }
-            }
+            o.par_iter_mut()
+                .enumerate()
+                .for_each(|(x, permutation_poly)| {
+                    let i = start + x;
+                    permutation_poly
+                        .par_iter_mut()
+                        .enumerate()
+                        .for_each(|(j, p)| {
+                            let (permuted_i, permuted_j) = mapping(i, j);
+                            *p = deltaomega[permuted_i][permuted_j];
+                        })
+                })
         });
     }
 
     let mut polys = vec![domain.empty_coeff(); p.columns.len()];
     {
         parallelize(&mut polys, |o, start| {
-            for (x, poly) in o.iter_mut().enumerate() {
+            o.par_iter_mut().enumerate().for_each(|(x, poly)| {
                 let i = start + x;
                 let permutation_poly = permutations[i].clone();
                 *poly = domain.lagrange_to_coeff(permutation_poly);
-            }
+            })
         });
     }
 
     let mut cosets = vec![domain.empty_extended(); p.columns.len()];
     {
         parallelize(&mut cosets, |o, start| {
-            for (x, coset) in o.iter_mut().enumerate() {
+            o.par_iter_mut().enumerate().for_each(|(x, coset)| {
                 let i = start + x;
                 let poly = polys[i].clone();
                 *coset = domain.coeff_to_extended(poly);
-            }
+            })
         });
     }
 


### PR DESCRIPTION
With these small modifications we get a ~20% improvement in my machine. These two images show that PK procedure did not use CPU to its capacity. 

Before:
![image](https://github.com/user-attachments/assets/767adf7a-de0c-4082-aca7-cdd9aef4cf10)

After: 
![image](https://github.com/user-attachments/assets/b9f3590f-1ddb-4bd4-821b-1395082d4700)

