### PR TITLE
PK size fix

### DIFF
--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -15,8 +15,8 @@ use super::{
     permutation, Challenge, Error, LagrangeCoeff, Polynomial, ProvingKey, VerifyingKey,
 };
 use crate::circuit::Value;
-use crate::poly::{batch_invert_rational, ExtendedLagrangeCoeff};
 use crate::poly::commitment::{Params, PolynomialCommitmentScheme};
+use crate::poly::{batch_invert_rational, ExtendedLagrangeCoeff};
 use crate::utils::rational::Rational;
 use crate::{poly::EvaluationDomain, utils::arithmetic::parallelize};
 
@@ -418,7 +418,7 @@ where
     // Compute l_last(X) which evaluates to 1 on the first inactive row (just
     // before the blinding factors) and 0 otherwise over the domain
     let mut l_last = vk.domain.empty_lagrange();
-    let n = l_last.len();
+    let n = vk.domain.n as usize;
     l_last[n - cs.blinding_factors() - 1] = F::ONE;
     let l_last = vk.domain.lagrange_to_coeff(l_last);
     let l_last = vk.domain.coeff_to_extended(l_last);

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -317,13 +317,9 @@ where
 
     /// Gets the total number of bytes in the serialization of `self`
     fn bytes_length(&self, format: SerdeFormat) -> usize {
-        let scalar_len = F::default().to_repr().as_ref().len();
         self.vk.bytes_length(format)
             + 12 // bytes used for encoding the length(u32) of "l0", "l_last" & "l_active_row" polys
-            + scalar_len * (self.l0.len() + self.l_last.len() + self.l_active_row.len())
             + polynomial_slice_byte_length(&self.fixed_values)
-            + polynomial_slice_byte_length(&self.fixed_polys)
-            + polynomial_slice_byte_length(&self.fixed_cosets)
             + self.permutation.bytes_length()
     }
 }
@@ -344,12 +340,7 @@ where
     ///   Does so by first writing the verifying key and then serializing the rest of the data (in the form of field polynomials)
     pub fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         self.vk.write(writer, format)?;
-        self.l0.write(writer)?;
-        self.l_last.write(writer)?;
-        self.l_active_row.write(writer)?;
         write_polynomial_slice(&self.fixed_values, writer)?;
-        write_polynomial_slice(&self.fixed_polys, writer)?;
-        write_polynomial_slice(&self.fixed_cosets, writer)?;
         self.permutation.write(writer)?;
         Ok(())
     }
@@ -376,13 +367,18 @@ where
             #[cfg(feature = "circuit-params")]
             params,
         )?;
-        let l0 = Polynomial::read(reader, format)?;
-        let l_last = Polynomial::read(reader, format)?;
-        let l_active_row = Polynomial::read(reader, format)?;
+        let [l0, l_last, l_active_row] = compute_lagrange_polys(&vk, &vk.cs);
         let fixed_values = read_polynomial_vec(reader, format)?;
-        let fixed_polys = read_polynomial_vec(reader, format)?;
-        let fixed_cosets = read_polynomial_vec(reader, format)?;
-        let permutation = permutation::ProvingKey::read(reader, format)?;
+        let fixed_polys: Vec<_> = fixed_values
+            .iter()
+            .map(|poly| vk.domain.lagrange_to_coeff(poly.clone()))
+            .collect();
+        let fixed_cosets = fixed_polys
+            .iter()
+            .map(|poly| vk.domain.coeff_to_extended(poly.clone()))
+            .collect();
+        let permutation =
+            permutation::ProvingKey::read(reader, format, &vk.domain, &vk.cs.permutation)?;
         let ev = Evaluator::new(vk.cs());
         Ok(Self {
             vk,

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -13,13 +13,13 @@ pub(crate) mod verifier;
 
 pub use keygen::Assembly;
 
+use crate::plonk::permutation::keygen::compute_polys_and_cosets;
 use crate::poly::commitment::PolynomialCommitmentScheme;
+use crate::poly::EvaluationDomain;
 use crate::utils::helpers::{byte_length, ProcessedSerdeObject};
 use ff::{PrimeField, WithSmallOrderMulGroup};
 use halo2curves::serde::SerdeObject;
 use std::io;
-use crate::plonk::permutation::keygen::compute_polys_and_cosets;
-use crate::poly::EvaluationDomain;
 
 /// A permutation argument.
 #[derive(Debug, Clone)]
@@ -137,9 +137,12 @@ pub(crate) struct ProvingKey<F: PrimeField> {
 
 impl<F: WithSmallOrderMulGroup<3> + SerdeObject> ProvingKey<F> {
     /// Reads proving key for a single permutation argument from buffer using `Polynomial::read`.  
-    pub(super) fn read<R: io::Read>(reader: &mut R, format: SerdeFormat,
-                                    domain: &EvaluationDomain<F>,
-                                    p: &Argument,) -> io::Result<Self> {
+    pub(super) fn read<R: io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+        domain: &EvaluationDomain<F>,
+        p: &Argument,
+    ) -> io::Result<Self> {
         let permutations = read_polynomial_vec(reader, format)?;
         let (polys, cosets) = compute_polys_and_cosets::<F>(domain, p, &permutations);
         Ok(ProvingKey {

--- a/src/plonk/permutation/keygen.rs
+++ b/src/plonk/permutation/keygen.rs
@@ -17,10 +17,10 @@ use {
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::poly::commitment::PolynomialCommitmentScheme;
+use crate::poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial};
 use rayon::iter::IntoParallelRefMutIterator;
 #[cfg(feature = "thread-safe-region")]
 use std::collections::{BTreeSet, HashMap};
-use crate::poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial};
 
 #[cfg(not(feature = "thread-safe-region"))]
 /// Struct that accumulates all the necessary data in order to construct the permutation argument.
@@ -440,7 +440,6 @@ pub(crate) fn build_vk<F: WithSmallOrderMulGroup<3>, CS: PolynomialCommitmentSch
     VerifyingKey { commitments }
 }
 
-
 #[allow(clippy::type_complexity)]
 pub(crate) fn compute_polys_and_cosets<F: WithSmallOrderMulGroup<3>>(
     domain: &EvaluationDomain<F>,
@@ -472,4 +471,3 @@ pub(crate) fn compute_polys_and_cosets<F: WithSmallOrderMulGroup<3>>(
     }
     (polys, cosets)
 }
-


### PR DESCRIPTION
This was already fixed in galois_recursion, but we forgot to bring it to the new fork. See previous changes [here](https://github.com/input-output-hk/galois_recursion/commit/142803bc69588b44e6c2b79e96f509e0dd005c0f)